### PR TITLE
Update REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,7 +10,6 @@ Plots
 PlotlyJS
 JLD
 Interact
-CrossfilterCharts
 PGFPlots
 RDatasets
 NBInclude


### PR DESCRIPTION
crossfiltercharts not usable with julia 1.0